### PR TITLE
use m12 class for checkboxes

### DIFF
--- a/system/modules/TinyMceFontAwesome/dca/tl_layout.php
+++ b/system/modules/TinyMceFontAwesome/dca/tl_layout.php
@@ -47,7 +47,7 @@ $GLOBALS['TL_DCA']['tl_layout']['fields']['tinyMceFontAwesome'] = array
 	'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['tinyMceFontAwesome'],
 	'exclude'                 => true,
 	'inputType'               => 'checkbox',
-	'eval'                    => array('tl_class' => 'clr w50'),
+	'eval'                    => array('tl_class' => 'clr w50 m12'),
 	'sql'                     => "char(1) NOT NULL default ''"
 );
 


### PR DESCRIPTION
Checkbox widgets should use the `m12` class, otherwise it won't look correct (as in it won't look like the layout of the core) when next to non-checkbox input fields.