### PR TITLE
Use real namespace instead of aliased classes

### DIFF
--- a/system/modules/TinyMceFontAwesome/classes/TinyMceFontAwesome.php
+++ b/system/modules/TinyMceFontAwesome/classes/TinyMceFontAwesome.php
@@ -32,6 +32,10 @@
  */
 namespace TinyMceFontAwesome;
 
+use Contao\LayoutModel;
+use Contao\PageModel;
+use Contao\PageRegular;
+
 /**
 * Class TinyMceFontAwesome
 *
@@ -73,7 +77,7 @@ class TinyMceFontAwesome {
 	 * @param $objPage
 	 * @param $objLayout
 	 */
-	public function hookGetPageLayout(\PageModel $objPage, \LayoutModel $objLayout, \PageRegular $objPageRegular)
+	public function hookGetPageLayout(PageModel $objPage, LayoutModel $objLayout, PageRegular $objPageRegular)
 	{
 		if($objLayout->tinyMceFontAwesome) {
 			$GLOBALS['TL_CSS']['TinyMceFontAwesome'] = $GLOBALS['TL_FONTAWESOME_CSS'];


### PR DESCRIPTION
Class overriding isn't supported in Contao 4 anymore so there's no reason to use the real classes instead.

This solves an compatibility issue with https://github.com/netzmacht/contao-page-context